### PR TITLE
Add debug package to log insetad of print directly to console

### DIFF
--- a/lib/partials-loader.js
+++ b/lib/partials-loader.js
@@ -6,6 +6,9 @@ var path = require('path');
 var _ = require('lodash');
 var fsHelper = require('fs-helper');
 
+// Log instead of printing directly to console
+const debug = require('debug')('print-loader:lib:partials-loader'); // eslint-disable-line no-console
+
 /** @param { String } library_name
  *      Used as a constant so debugging is simple
  */
@@ -16,13 +19,13 @@ var library_name = 'partial-loader';
  *  	the call to this function the template engine that was used should have the partials that exist in the
  *  	directories provided registered and ready for use. The idea is that the template_root_directories indicate
  *  	the top level folder to parse through for a directory whose name exists in the partials_directory_names. If
- *  	a directory name is found under the template directory and it exists in the partials_directory_names, then 
+ *  	a directory name is found under the template directory and it exists in the partials_directory_names, then
  *  	the loader iterates in a recursive fashion from the partials directory down, registering each file that has an
  *  	extension that is found in the template_extensions. ]
  * @param { Object } options                                               [ This is a container object for the partials-loader to use. ]
  * @param { Object } options.engine_reference                              [ This is the template engine that the partials files found will be registered with. ]
  * @param { String or Array of Strings } options.template_root_directories [ These are the template root directories that will be recursively searched through. ]
- * @param { String or Array of Strings } options.partials_directory_names  [ These are the directory names that will be matched against in order to identify a directory to recurse through for loading partials files. SPECIAL CHARACTERS: if the character '.' is passed in, this will indicate to the partials loader that the template directory itself should be loaded as a partials directory. If it is passed in with an array of other strings the '.' will take precedence and will just iterate from the template directory down and 
+ * @param { String or Array of Strings } options.partials_directory_names  [ These are the directory names that will be matched against in order to identify a directory to recurse through for loading partials files. SPECIAL CHARACTERS: if the character '.' is passed in, this will indicate to the partials loader that the template directory itself should be loaded as a partials directory. If it is passed in with an array of other strings the '.' will take precedence and will just iterate from the template directory down and
  * @param { String OR Array of Strings } options.template_extensions       [ These are the extensions of the template files to load. ]
  * @param { String } options.delimiter_symbol                              [ This is the delimiter used for namespacing, when files are loaded their directories are separated by this value. ]
  * @return { undefined }                                                   [ This returns nothing. ]
@@ -51,8 +54,8 @@ exports.handlebars = function(options) {
 	}
 }
 
-/** loadPartials 
- * 		[ This function is responsible for taking all the formatted data pointing to all the partials and recurseive 
+/** loadPartials
+ * 		[ This function is responsible for taking all the formatted data pointing to all the partials and recurseive
  * 		directories, and using that information to load the partial files into the template engine.]
  * @param { Object } template_engine_reference    [ This is the object reference to the template engine that is loading the the partials ]
  * @param { String } root_directory               [ This is the root directory that is being loaded from. ]
@@ -75,10 +78,10 @@ var loadPartials = function(template_engine_reference, root_directory, current_d
 				var partial_name_space = fsHelper.getDirDifference(root_directory, fullPath);
 				partial_name_space = partial_name_space.replace(/\\/g, delimiter_symbol);
 
-				console.log('Loading Partial into Handlebars engine.');
-				console.log('\tPartial Name Space: ' + partial_name_space);
-				console.log('\tFull Path to NameSpace: ' + fullPath);
-				console.log('-----------------------------------------');
+				debug('Loading Partial into Handlebars engine.');
+				debug('\tPartial Name Space: ' + partial_name_space);
+				debug('\tFull Path to NameSpace: ' + fullPath);
+				debug('-----------------------------------------');
 
 				template_engine_reference.registerPartial(partial_name_space, template);
 			}
@@ -187,4 +190,4 @@ var validateTemplateExtensions = function(template_extensions) {
 		new Error('The template extensions passed into the ' + library_name + ' function are not an ARRAY or STRING type. Please fix this.')
 	}
 	return template_extensions;
-} 
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "partials-loader",
+  "version": "0.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/Bill4Time/partials-loader",
   "dependencies": {
+    "debug": "^3.1.0",
     "fs-helper": "^0.1.0",
     "lodash": "^2.4.1"
   },


### PR DESCRIPTION
Use debug package for log instead of printing to console log.
This will prevent non-wanted printing a lot of log lines.
If a user wants to see what partials are loaded, just set debug target:

`$ DEBUG=* node index.js`

Change:
* Add debug package
* Change `console.log()` with `debug()`
* Remove some extra spaces from line endings.
